### PR TITLE
Fix an issue with singleton destruction order

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Version
 
-Masala's Core library is currently version 1.5.
+Masala's Core library is currently version 1.6.
 
 ## Description
 
@@ -96,6 +96,7 @@ Masala is released under an AGPL version 3 licence.  This licence permits anyone
 
 ## Version history
 
+* Version 1.6: Fix an occasional bug when applications that link Masala terminate, caused by the order in which Masala's singletons (particularly the thread manager and the tracer manager) are destroyed.
 * Version 1.5: Update buildscripts to remove language feature incompatible with Python older than version 3.9 (tuple type hinting).
 * Version 1.4: Minor adjustments to generate\_library\_api.py for compatibility with the Masala SYCL loop closure plugins.
 * Version 1.3: Introduction of the HilbertIndexedMatrix for more efficient searches of data in matrices with fewer cache misses.

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -19,7 +19,7 @@
 CMAKE_MINIMUM_REQUIRED( VERSION 3.10 )
 
 # Set project attributes:
-PROJECT( Masala VERSION 1.5 DESCRIPTION "The Masala molecular modelling suite, combining the best of physics-based simulations and machine-learning based methods." )
+PROJECT( Masala VERSION 1.6 DESCRIPTION "The Masala molecular modelling suite, combining the best of physics-based simulations and machine-learning based methods." )
 
 # Default build is release mode.  To build in debug mode (recommeded for development),
 # change the nex tline to SET( MODE debug ).

--- a/src/base/MasalaObject.cc
+++ b/src/base/MasalaObject.cc
@@ -95,6 +95,16 @@ MasalaObject::write_to_tracer(
     }
 }
 
+/// @brief Writes text to the tracer, using the MasalaTracerManager, with a safety check for whether
+/// the MasalaTracerManager has been spun down.
+/// @details Threadsafe, but DO NOT USE FROM CONSTRUCTOR!
+void
+MasalaObject::write_to_tracer_with_spindown_check(
+	std::string const & message
+) const {
+	masala::base::managers::tracer::MasalaTracerManager::write_to_tracer_with_spindown_check( class_namespace_and_name(), message, false );
+}
+
 /// @brief Get a creator object for objects of this type.
 /// @details By default, returns nullptr.  Can be overridden by derived classes.
 masala::base::managers::plugin_module::MasalaPluginCreatorCSP

--- a/src/base/MasalaObject.hh
+++ b/src/base/MasalaObject.hh
@@ -116,6 +116,14 @@ public:
 		std::string const & message
 	) const;
 
+	/// @brief Writes text to the tracer, using the MasalaTracerManager, with a safety check for whether
+	/// the MasalaTracerManager has been spun down.
+	/// @details Threadsafe, but DO NOT USE FROM CONSTRUCTOR!
+	void
+	write_to_tracer_with_spindown_check(
+		std::string const & message
+	) const;
+
 	/// @brief Get a creator object for objects of this type.
 	/// @details By default, returns nullptr.  Can be overridden by derived classes.
 	virtual

--- a/src/base/managers/threads/thread_pool/MasalaThreadPool.cc
+++ b/src/base/managers/threads/thread_pool/MasalaThreadPool.cc
@@ -78,7 +78,7 @@ MasalaThreadPool::~MasalaThreadPool() {
     std::lock_guard< std::mutex > lock( thread_pool_mutex_ );
     thread_pool_state_ = MasalaThreadPoolState::ALL_THREADS_SPINNING_DOWN;
     for( std::vector< MasalaThreadSP >::iterator it( threads_.begin() ); it != threads_.end(); ) {
-        write_to_tracer( "Terminating thread " + std::to_string( (*it)->thread_index() ) + "." );
+        write_to_tracer_with_spindown_check( "Terminating thread " + std::to_string( (*it)->thread_index() ) + "." );
         {
             std::unique_lock< std::mutex > lock2( (*it)->thread_mutex() );
             (*it)->set_forced_idle(true);

--- a/src/base/managers/tracer/MasalaTracerManager.hh
+++ b/src/base/managers/tracer/MasalaTracerManager.hh
@@ -96,6 +96,16 @@ public:
 	/// @brief Instantiate the static singleton and get a handle to it.
 	static MasalaTracerManagerHandle get_instance();
 
+	/// @brief Write to the tracer manager if it has not yet been spun down, and to std::cout otherwise.
+	/// @returns True if we wrote to the tracer manager, false otherwise.
+	static
+	bool
+	write_to_tracer_with_spindown_check(
+		std::string const & tracer_name,
+		std::string const & message,
+		bool const skip_check = false
+	);
+
 private:
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/masala_core_library.md
+++ b/src/masala_core_library.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-The Masala Core library version 1.5 defines the plugin system, the API definition system, and static singletons for managing shared resources like memory, output loggers (tracers), disk i/o, CPU threads, and MPI processes.  It also defines base classes for certain types of Masala plugin modules.
+The Masala Core library version 1.6 defines the plugin system, the API definition system, and static singletons for managing shared resources like memory, output loggers (tracers), disk i/o, CPU threads, and MPI processes.  It also defines base classes for certain types of Masala plugin modules.
 
 ## Authors
 
@@ -31,3 +31,13 @@ The corresponding auto-generated libraries are in the following namespaces:
 ## Linking this library
 
 If you link this library at compilation time, it is _only_ safe to directly call functions or instantiate classes in the auto-generated API namespaces, or in the \link masala::base \endlink namespace.  These have stable APIs that will be preserved in future versions of the Standard Masala Plugins library, or deprecated in a manner that provides ample warning.  Handwritten sub-libraries other than the base sub-libarry are _not_ part of the API, and can change without warning.
+
+## Version history
+
+* Version 1.6: Fix an occasional bug when applications that link Masala terminate, caused by the order in which Masala's singletons (particularly the thread manager and the tracer manager) are destroyed.
+* Version 1.5: Update buildscripts to remove language feature incompatible with Python older than version 3.9 (tuple type hinting).
+* Version 1.4: Minor adjustments to generate\_library\_api.py for compatibility with the Masala SYCL loop closure plugins.
+* Version 1.3: Introduction of the HilbertIndexedMatrix for more efficient searches of data in matrices with fewer cache misses.
+* Version 1.2: Small tweak to element names in the ElementType enum class, to avoid name conflicts with "I" (which is often used for identitiy matrices).
+* Version 1.1: Small bugfix to RVL optimizer base classes.  (A float-float comparison could sometimes fail due to machine precision limits.)
+* Version 1.0: Initial non-beta release.  Infrastructure for the plugin system, CPU thread management, CFN optimizer base classes, and RVL optimizer base classes fully implemented.


### PR DESCRIPTION
If the tracer manager is destroyed prior to the thread manager, problems
can arise when the thread manager reports spindown of threads. This PR
aims to address this.  This also updates Masala to version 1.6.